### PR TITLE
Add build-essential to .NET image

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -5,7 +5,7 @@ ENV DOCKER_VERSION 20.10.22
 
 RUN set -x && \
     apt-get update && \
-    apt-get -y install unzip jq gettext-base
+    apt-get -y install unzip jq gettext-base build-essential
 
 RUN curl -L -o /tmp/docker-$DOCKER_VERSION.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz && \
     tar -xz -C /tmp -f /tmp/docker-$DOCKER_VERSION.tgz && \


### PR DESCRIPTION
This adds GNU Make, which several projects use, plus GCC and few other useful tools.