### PR TITLE
dotnet 10-preview

### DIFF
--- a/10-preview/Dockerfile
+++ b/10-preview/Dockerfile
@@ -1,0 +1,14 @@
+FROM cimg/base:current@sha256:6438d46397dbdff5b4da4a95c29dd469d0c8d7408abc682874c09173249dfaea
+
+# This convenience image by Circle CI (https://github.com/CircleCI-Public/cimg-base) runs Ubuntu 22.04
+# in which you can install .NET 10.0 only by using backports ppa.
+# See https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#supported-distributions
+
+RUN sudo add-apt-repository ppa:dotnet/previews && \
+   sudo apt-get update && \
+   sudo apt-get -y install gettext-base dotnet-sdk-10.0
+
+# Install trx2junit to be used during build
+RUN dotnet tool install -g trx2junit
+
+ENV PATH="${PATH}:/home/circleci/.dotnet/tools"

--- a/10-preview/Dockerfile
+++ b/10-preview/Dockerfile
@@ -1,9 +1,5 @@
 FROM cimg/base:current@sha256:6438d46397dbdff5b4da4a95c29dd469d0c8d7408abc682874c09173249dfaea
 
-# This convenience image by Circle CI (https://github.com/CircleCI-Public/cimg-base) runs Ubuntu 22.04
-# in which you can install .NET 10.0 only by using backports ppa.
-# See https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#supported-distributions
-
 RUN sudo add-apt-repository ppa:dotnet/previews && \
    sudo apt-get update && \
    sudo apt-get -y install gettext-base dotnet-sdk-10.0


### PR DESCRIPTION
To be able to do CI builds for apps using https://github.com/tibber/image-dotnet/blob/main/10-chiseled-preview/Dockerfile

Testing:

```sh
❯ docker build .
[+] Building 117.1s (7/7) FINISHED                                                                                                               docker:default
 => [internal] load build definition from Dockerfile                                                                                                       0.1s
 => => transferring dockerfile: 728B                                                                                                                       0.0s
 => [internal] load metadata for docker.io/cimg/base:current@sha256:6438d46397dbdff5b4da4a95c29dd469d0c8d7408abc682874c09173249dfaea                       0.1s
 => [internal] load .dockerignore                                                                                                                          0.1s
 => => transferring context: 2B                                                                                                                            0.0s
 => CACHED [1/3] FROM docker.io/cimg/base:current@sha256:6438d46397dbdff5b4da4a95c29dd469d0c8d7408abc682874c09173249dfaea                                  0.0s
 => [2/3] RUN sudo add-apt-repository ppa:dotnet/previews &&    sudo apt-get update &&    sudo apt-get -y install gettext-base dotnet-sdk-10.0           106.7s
 => [3/3] RUN dotnet tool install -g trx2junit                                                                                                             4.2s 
 => exporting to image                                                                                                                                     5.6s 
 => => exporting layers                                                                                                                                    5.6s 
 => => writing image sha256:97ac1d7954d6716366a3476e2752116244c795168366aa81aa078166e740a69c                                                               0.0s 
❯ docker run -ti sha256:97ac1d7954d6716366a3476e2752116244c795168366aa81aa078166e740a69c dotnet --list-sdks
10.0.100-preview.7.25380.108 [/usr/lib/dotnet/sdk]
```