### PR TITLE
new image tag: `10`

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -1,0 +1,10 @@
+FROM cimg/base:current@sha256:6438d46397dbdff5b4da4a95c29dd469d0c8d7408abc682874c09173249dfaea
+
+RUN sudo add-apt-repository ppa:dotnet/previews && \
+   sudo apt-get update && \
+   sudo apt-get -y install gettext-base dotnet-sdk-10.0
+
+# Install trx2junit to be used during build
+RUN dotnet tool install -g trx2junit
+
+ENV PATH="${PATH}:/home/circleci/.dotnet/tools"

--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ This repository is needed because Circle CI does not have a ready-made image for
 
 List of image tags:
 
-| Tag      | Based on                                | Description                                                         |
-| :---:    | :---:                                   | :---:                                                               |
-| 6        | cimg/base:current                       | Circle CI base image with .NET `dotnet-sdk-6.0` installed from Microsofts's package repository. Supports buildx used by `aws-ecr` orb.   |
-| 7-alpine | mcr.microsoft.com/dotnet/sdk:7.0-alpine | Microsoft Alpine image with Docker installed. Does not support Docker buildx / Buildkit.                      |
-| 7        | cimg/base:current                       | Circle CI base image with .NET `dotnet-sdk-7.0` installed from Microsofts's package repository. Supports buildx used by `aws-ecr` orb.   |
-| 8        | cimg/base:current                       | Circle CI base image with .NET `dotnet-sdk-8.0` installed from Microsofts's package repository. Supports buildx used by `aws-ecr` orb.   |
-| 9        | cimg/base:current                       | Circle CI base image with .NET `dotnet-sdk-9.0` installed from Ubuntu's package repository (backport ppa needed for 22.04). Supports buildx used by `aws-ecr` orb.   |
+| Tag        | Based on                                | Description                                                         |
+| :---:      | :---:                                   | :---:                                                               |
+| 6          | cimg/base:current                       | Circle CI base image with .NET `dotnet-sdk-6.0` installed from Microsofts's package repository. Supports buildx used by `aws-ecr` orb.   |
+| 7-alpine   | mcr.microsoft.com/dotnet/sdk:7.0-alpine | Microsoft Alpine image with Docker installed. Does not support Docker buildx / Buildkit.                      |
+| 7          | cimg/base:current                       | Circle CI base image with .NET `dotnet-sdk-7.0` installed from Microsofts's package repository. Supports buildx used by `aws-ecr` orb.   |
+| 8          | cimg/base:current                       | Circle CI base image with .NET `dotnet-sdk-8.0` installed from Microsofts's package repository. Supports buildx used by `aws-ecr` orb.   |
+| 9          | cimg/base:current                       | Circle CI base image with .NET `dotnet-sdk-9.0` installed from Ubuntu's package repository (backport ppa needed for 22.04). Supports buildx used by `aws-ecr` orb.   |
+| 10-preview | cimg/base:current                       | Circle CI base image with .NET `dotnet-sdk-10`  installed from Ubuntu's ppa:dotnet/preview repository. Supports buildx used by `aws-ecr` orb.   |
+| 10         | cimg/base:current                       | Circle CI base image with .NET `dotnet-sdk-10` installed from Ubuntu's ppa:dotnet/preview repository starting with `rc.1`. Will transition to stable as it becomes available. Supports buildx used by `aws-ecr` orb.   |
 
 # This image is built in Dockerhub


### PR DESCRIPTION
This tag is meant for .NET 10 stable, but starts out using `rc.1` as it's under go-live license (e.g. supported) and no breaking changes are allowed for .NET RCs.