### PR TITLE
dotnet 10 LTS

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -1,10 +1,39 @@
 FROM cimg/base:current@sha256:914f8f3896bc4033634a446552a8c256f19fdb56aa4e999cf493961d0681bc48
 
-RUN sudo add-apt-repository ppa:dotnet/previews && \
-   sudo apt-get update && \
-   sudo apt-get -y install gettext-base dotnet-sdk-10.0
+# Install GPG and import Microsoft's public key for dotnet-install script verification
+RUN set -x && \
+    sudo apt-get update && \
+    sudo apt-get -y install gpg && \
+    sudo rm -rf /var/lib/apt/lists/* && \
+    # Download and import Microsoft's public key
+    wget https://dot.net/v1/dotnet-install.asc && \
+    gpg --import dotnet-install.asc && \
+    rm dotnet-install.asc
+
+# Download, verify, and install .NET SDK 10.0
+RUN set -x && \
+    # Download the installation script and its signature
+    wget https://dot.net/v1/dotnet-install.sh && \
+    wget https://dot.net/v1/dotnet-install.sig && \
+    # Verify the GPG signature
+    gpg --verify dotnet-install.sig dotnet-install.sh && \
+    # Make script executable and run installation
+    chmod +x dotnet-install.sh && \
+    sudo ./dotnet-install.sh --channel 10.0 --install-dir /usr/share/dotnet && \
+    # Cleanup
+    rm dotnet-install.sh dotnet-install.sig && \
+    sudo ln -s /usr/share/dotnet/dotnet /usr/local/bin/dotnet
+
+RUN sudo apt-get update && \
+    sudo apt-get -y install gettext-base && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    DOTNET_ROOT=/usr/share/dotnet \
+    PATH="${PATH}:/home/circleci/.dotnet/tools"
 
 # Install trx2junit to be used during build
 RUN dotnet tool install -g trx2junit
 
 ENV PATH="${PATH}:/home/circleci/.dotnet/tools"
+ENV DOTNET_ROOT=/usr/share/dotnet

--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -1,8 +1,7 @@
 FROM cimg/base:current@sha256:914f8f3896bc4033634a446552a8c256f19fdb56aa4e999cf493961d0681bc48
 
 # Install GPG and import Microsoft's public key for dotnet-install script verification
-RUN set -x && \
-    sudo apt-get update && \
+RUN sudo apt-get update && \
     sudo apt-get -y install gpg && \
     sudo rm -rf /var/lib/apt/lists/* && \
     # Download and import Microsoft's public key
@@ -11,9 +10,7 @@ RUN set -x && \
     rm dotnet-install.asc
 
 # Download, verify, and install .NET SDK 10.0
-RUN set -x && \
-    # Download the installation script and its signature
-    wget https://dot.net/v1/dotnet-install.sh && \
+RUN wget https://dot.net/v1/dotnet-install.sh && \
     wget https://dot.net/v1/dotnet-install.sig && \
     # Verify the GPG signature
     gpg --verify dotnet-install.sig dotnet-install.sh && \
@@ -34,6 +31,3 @@ ENV DOTNET_CLI_TELEMETRY_OPTOUT=1 \
 
 # Install trx2junit to be used during build
 RUN dotnet tool install -g trx2junit
-
-ENV PATH="${PATH}:/home/circleci/.dotnet/tools"
-ENV DOTNET_ROOT=/usr/share/dotnet

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ List of image tags:
 | 7          | cimg/base:current                       | Circle CI base image with .NET `dotnet-sdk-7.0` installed from Microsofts's package repository. Supports buildx used by `aws-ecr` orb.   |
 | 8          | cimg/base:current                       | Circle CI base image with .NET `dotnet-sdk-8.0` installed from Microsofts's package repository. Supports buildx used by `aws-ecr` orb.   |
 | 9          | cimg/base:current                       | Circle CI base image with .NET `dotnet-sdk-9.0` installed from Ubuntu's package repository (backport ppa needed for 22.04). Supports buildx used by `aws-ecr` orb.   |
-| 10         | cimg/base:current                       | Circle CI base image with .NET `dotnet-sdk-10` installed from Ubuntu's ppa:dotnet/preview repository starting with `rc.1`. Will transition to stable as it becomes available. Supports buildx used by `aws-ecr` orb.   |
+| 10         | cimg/base:current                       | Circle CI base image with .NET SDK 10.0 installed via `dotnet-install.sh` w/ signature verification. Supports buildx used by `aws-ecr` orb.   |
 
 # This image is built in Dockerhub


### PR DESCRIPTION
.NET 10 still only available for Ubuntu 22.04 (via backports PPA)
https://documentation.ubuntu.com/ubuntu-for-developers/reference/availability/dotnet/
And CircleCI's `cimg/base:current` is nowadays running 24.04.

Since
1. we've had some issues w/ different sources for different .NET versions, let's just use `dotnet-install.sh`.
2. we also want to avoid this: https://learn.microsoft.com/en-us/dotnet/core/install/linux-package-mixup?pivots=os-linux-ubuntu#whats-going-on

Does PGP signature verification of the install script.

<details>
<summary>Full build output</summary>

```
❯ docker build --no-cache --progress=plain -t dotnet-10-final-ci3 .
#0 building with "default" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 1.58kB done
#1 DONE 0.1s

#2 [internal] load metadata for docker.io/cimg/base:current@sha256:914f8f3896bc4033634a446552a8c256f19fdb56aa4e999cf493961d0681bc48
#2 DONE 1.1s

#3 [internal] load .dockerignore
#3 transferring context: 2B done
#3 DONE 0.1s

#4 [1/5] FROM docker.io/cimg/base:current@sha256:914f8f3896bc4033634a446552a8c256f19fdb56aa4e999cf493961d0681bc48
#4 CACHED

#5 [2/5] RUN set -x &&     sudo apt-get update &&     sudo apt-get -y install gpg &&     sudo rm -rf /var/lib/apt/lists/* &&     wget https://dot.net/v1/dotnet-install.asc &&     gpg --import dotnet-install.asc &&     rm dotnet-install.asc
#5 0.389 + set -x
#5 0.389 + sudo apt-get update
#5 0.510 Get:1 https://download.docker.com/linux/ubuntu noble InRelease [48.5 kB]
#5 0.540 Get:2 http://security.ubuntu.com/ubuntu noble-security InRelease [126 kB]
#5 0.622 Get:3 https://download.docker.com/linux/ubuntu noble/stable amd64 Packages [43.8 kB]
#5 0.703 Get:4 http://archive.ubuntu.com/ubuntu noble InRelease [256 kB]
#5 0.732 Get:5 http://security.ubuntu.com/ubuntu noble-security/main amd64 Packages [1,648 kB]
#5 0.837 Get:6 https://ppa.launchpadcontent.net/git-core/ppa/ubuntu noble InRelease [24.3 kB]
#5 0.919 Get:7 https://ppa.launchpadcontent.net/git-core/ppa/ubuntu noble/main amd64 Packages [2,987 B]
#5 0.983 Get:8 http://security.ubuntu.com/ubuntu noble-security/universe amd64 Packages [1,173 kB]
#5 1.026 Get:9 http://security.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [2,714 kB]
#5 1.128 Get:10 http://security.ubuntu.com/ubuntu noble-security/multiverse amd64 Packages [33.1 kB]
#5 1.437 Get:12 http://archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
#5 1.485 Get:11 https://packagecloud.io/github/git-lfs/ubuntu noble InRelease [29.2 kB]
#5 1.597 Get:13 http://archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
#5 1.759 Get:15 http://archive.ubuntu.com/ubuntu noble/restricted amd64 Packages [117 kB]
#5 1.803 Get:16 http://archive.ubuntu.com/ubuntu noble/universe amd64 Packages [19.3 MB]
#5 1.925 Get:14 https://packagecloud.io/github/git-lfs/ubuntu noble/main amd64 Packages [1,273 B]
#5 3.249 Get:17 http://archive.ubuntu.com/ubuntu noble/multiverse amd64 Packages [331 kB]
#5 3.250 Get:18 http://archive.ubuntu.com/ubuntu noble/main amd64 Packages [1,808 kB]
#5 3.255 Get:19 http://archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [2,847 kB]
#5 3.263 Get:20 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [2,007 kB]
#5 3.397 Get:21 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [1,941 kB]
#5 3.499 Get:22 http://archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Packages [35.9 kB]
#5 3.500 Get:23 http://archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [33.9 kB]
#5 3.500 Get:24 http://archive.ubuntu.com/ubuntu noble-backports/main amd64 Packages [49.4 kB]
#5 3.939 Fetched 34.8 MB in 3s (9,995 kB/s)
#5 3.939 Reading package lists...
#5 4.461 W: https://download.docker.com/linux/ubuntu/dists/noble/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
#5 4.462 + sudo apt-get -y install gpg
#5 4.496 Reading package lists...
#5 5.015 Building dependency tree...
#5 5.120 Reading state information...
#5 5.305 gpg is already the newest version (2.4.4-2ubuntu17.3).
#5 5.305 gpg set to manually installed.
#5 5.305 0 upgraded, 0 newly installed, 0 to remove and 35 not upgraded.
#5 5.306 + sudo rm -rf /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble-backports_InRelease /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble-backports_main_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble-backports_universe_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble_InRelease /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble_main_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble_multiverse_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble_restricted_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble_universe_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble-updates_InRelease /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble-updates_main_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble-updates_multiverse_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble-updates_restricted_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble-updates_universe_binary-amd64_Packages.lz4 /var/lib/apt/lists/auxfiles /var/lib/apt/lists/download.docker.com_linux_ubuntu_dists_noble_InRelease /var/lib/apt/lists/download.docker.com_linux_ubuntu_dists_noble_stable_binary-amd64_Packages.lz4 /var/lib/apt/lists/lock /var/lib/apt/lists/packagecloud.io_github_git-lfs_ubuntu_dists_noble_InRelease /var/lib/apt/lists/packagecloud.io_github_git-lfs_ubuntu_dists_noble_main_binary-amd64_Packages.lz4 /var/lib/apt/lists/partial /var/lib/apt/lists/ppa.launchpadcontent.net_git-core_ppa_ubuntu_dists_noble_InRelease /var/lib/apt/lists/ppa.launchpadcontent.net_git-core_ppa_ubuntu_dists_noble_main_binary-amd64_Packages.lz4 /var/lib/apt/lists/security.ubuntu.com_ubuntu_dists_noble-security_InRelease /var/lib/apt/lists/security.ubuntu.com_ubuntu_dists_noble-security_main_binary-amd64_Packages.lz4 /var/lib/apt/lists/security.ubuntu.com_ubuntu_dists_noble-security_multiverse_binary-amd64_Packages.lz4 /var/lib/apt/lists/security.ubuntu.com_ubuntu_dists_noble-security_restricted_binary-amd64_Packages.lz4 /var/lib/apt/lists/security.ubuntu.com_ubuntu_dists_noble-security_universe_binary-amd64_Packages.lz4
#5 5.315 + wget https://dot.net/v1/dotnet-install.asc
#5 5.316 --2025-11-18 09:55:40--  https://dot.net/v1/dotnet-install.asc
#5 5.333 Resolving dot.net (dot.net)... 20.112.250.133, 20.236.44.162, 20.231.239.246, ...
#5 5.371 Connecting to dot.net (dot.net)|20.112.250.133|:443... connected.
#5 5.631 HTTP request sent, awaiting response... 301 Moved Permanently
#5 5.883 Location: https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.asc [following]
#5 5.883 --2025-11-18 09:55:40--  https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.asc
#5 5.883 Resolving builds.dotnet.microsoft.com (builds.dotnet.microsoft.com)... 213.136.45.98, 213.136.45.9, 2001:9b0:1:313::4f88:3d29, ...
#5 5.907 Connecting to builds.dotnet.microsoft.com (builds.dotnet.microsoft.com)|213.136.45.98|:443... connected.
#5 5.936 HTTP request sent, awaiting response... 200 OK
#5 5.964 Length: 983 [application/octet-stream]
#5 5.991 Saving to: ‘dotnet-install.asc’
#5 5.991 
#5 5.991      0K                                                       100%  379M=0s
#5 5.991 
#5 5.991 2025-11-18 09:55:40 (379 MB/s) - ‘dotnet-install.asc’ saved [983/983]
#5 5.991 
#5 5.991 + gpg --import dotnet-install.asc
#5 5.993 gpg: directory '/home/circleci/.gnupg' created
#5 5.993 gpg: keybox '/home/circleci/.gnupg/pubring.kbx' created
#5 5.993 gpg: /home/circleci/.gnupg/trustdb.gpg: trustdb created
#5 5.993 gpg: key B9CF1A51FC7D3ACF: public key "Microsoft DevUXTeamPrague <devuxteamprague@microsoft.com>" imported
#5 5.997 gpg: Total number processed: 1
#5 5.997 gpg:               imported: 1
#5 5.997 + rm dotnet-install.asc
#5 DONE 6.1s

#6 [3/5] RUN set -x &&     wget https://dot.net/v1/dotnet-install.sh &&     wget https://dot.net/v1/dotnet-install.sig &&     gpg --verify dotnet-install.sig dotnet-install.sh &&     chmod +x dotnet-install.sh &&     sudo ./dotnet-install.sh --channel 10.0 --install-dir /usr/share/dotnet &&     rm dotnet-install.sh dotnet-install.sig &&     sudo ln -s /usr/share/dotnet/dotnet /usr/local/bin/dotnet
#6 0.338 + set -x
#6 0.338 + wget https://dot.net/v1/dotnet-install.sh
#6 0.340 --2025-11-18 09:55:41--  https://dot.net/v1/dotnet-install.sh
#6 0.356 Resolving dot.net (dot.net)... 20.236.44.162, 20.231.239.246, 20.70.246.20, ...
#6 0.365 Connecting to dot.net (dot.net)|20.236.44.162|:443... connected.
#6 0.691 HTTP request sent, awaiting response... 301 Moved Permanently
#6 1.013 Location: https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh [following]
#6 1.013 --2025-11-18 09:55:42--  https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh
#6 1.013 Resolving builds.dotnet.microsoft.com (builds.dotnet.microsoft.com)... 213.136.45.9, 213.136.45.98, 2001:9b0:1:313::4f88:3d2b, ...
#6 1.015 Connecting to builds.dotnet.microsoft.com (builds.dotnet.microsoft.com)|213.136.45.9|:443... connected.
#6 1.044 HTTP request sent, awaiting response... 200 OK
#6 1.077 Length: unspecified [application/octet-stream]
#6 1.104 Saving to: ‘dotnet-install.sh’
#6 1.104 
#6 1.104      0K .......... .......... .......... .......... ..........  458M
#6 1.104     50K .......... ..                                          22.7T=0s
#6 1.104 
#6 1.104 2025-11-18 09:55:42 (569 MB/s) - ‘dotnet-install.sh’ saved [63666]
#6 1.104 
#6 1.110 + wget https://dot.net/v1/dotnet-install.sig
#6 1.112 --2025-11-18 09:55:42--  https://dot.net/v1/dotnet-install.sig
#6 1.127 Resolving dot.net (dot.net)... 20.231.239.246, 20.70.246.20, 20.76.201.171, ...
#6 1.136 Connecting to dot.net (dot.net)|20.231.239.246|:443... connected.
#6 1.370 HTTP request sent, awaiting response... 301 Moved Permanently
#6 1.598 Location: https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sig [following]
#6 1.598 --2025-11-18 09:55:42--  https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sig
#6 1.598 Resolving builds.dotnet.microsoft.com (builds.dotnet.microsoft.com)... 213.136.45.98, 213.136.45.9, 2001:9b0:1:313::4f88:3d29, ...
#6 1.600 Connecting to builds.dotnet.microsoft.com (builds.dotnet.microsoft.com)|213.136.45.98|:443... connected.
#6 1.629 HTTP request sent, awaiting response... 200 OK
#6 1.657 Length: 481 [application/octet-stream]
#6 1.658 Saving to: ‘dotnet-install.sig’
#6 1.658 
#6 1.658      0K                                                       100%  261M=0s
#6 1.658 
#6 1.658 2025-11-18 09:55:42 (261 MB/s) - ‘dotnet-install.sig’ saved [481/481]
#6 1.658 
#6 1.658 + gpg --verify dotnet-install.sig dotnet-install.sh
#6 1.674 gpg: Signature made Mon 29 Sep 2025 06:27:31 PM UTC
#6 1.674 gpg:                using RSA key B9CF1A51FC7D3ACF
#6 1.681 gpg: Good signature from "Microsoft DevUXTeamPrague <devuxteamprague@microsoft.com>" [unknown]
#6 1.681 gpg: WARNING: This key is not certified with a trusted signature!
#6 1.681 gpg:          There is no indication that the signature belongs to the owner.
#6 1.681 Primary key fingerprint: 2B93 0AB1 228D 11D5 D7F6  B6AC B9CF 1A51 FC7D 3ACF
#6 1.681 + chmod +x dotnet-install.sh
#6 1.682 + sudo ./dotnet-install.sh --channel 10.0 --install-dir /usr/share/dotnet
#6 2.044 dotnet-install: Attempting to download using aka.ms link https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100/dotnet-sdk-10.0.100-linux-x64.tar.gz
#6 9.418 dotnet-install: Remote file https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100/dotnet-sdk-10.0.100-linux-x64.tar.gz size is 239125653 bytes.
#6 9.418 dotnet-install: Extracting archive from https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100/dotnet-sdk-10.0.100-linux-x64.tar.gz
#6 13.50 dotnet-install: Downloaded file size is 239125653 bytes.
#6 13.50 dotnet-install: The remote and local file sizes are equal.
#6 13.62 dotnet-install: Installed version is 10.0.100
#6 13.62 dotnet-install: Adding to current process PATH: `/usr/share/dotnet`. Note: This change will be visible only when sourcing script.
#6 13.62 dotnet-install: Note that the script does not resolve dependencies during installation.
#6 13.62 dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
#6 13.62 dotnet-install: Installation finished successfully.
#6 13.62 + rm dotnet-install.sh dotnet-install.sig
#6 13.62 + sudo ln -s /usr/share/dotnet/dotnet /usr/local/bin/dotnet
#6 DONE 13.8s

#7 [4/5] RUN sudo apt-get update &&     sudo apt-get -y install gettext-base &&     sudo rm -rf /var/lib/apt/lists/*
#7 0.353 + sudo apt-get update
#7 0.456 Get:1 https://download.docker.com/linux/ubuntu noble InRelease [48.5 kB]
#7 0.478 Get:2 http://security.ubuntu.com/ubuntu noble-security InRelease [126 kB]
#7 0.515 Get:3 http://archive.ubuntu.com/ubuntu noble InRelease [256 kB]
#7 0.562 Get:4 https://download.docker.com/linux/ubuntu noble/stable amd64 Packages [43.8 kB]
#7 0.634 Get:5 https://ppa.launchpadcontent.net/git-core/ppa/ubuntu noble InRelease [24.3 kB]
#7 0.660 Get:6 http://security.ubuntu.com/ubuntu noble-security/multiverse amd64 Packages [33.1 kB]
#7 0.700 Get:7 http://security.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [2,714 kB]
#7 0.709 Get:8 http://archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
#7 0.712 Get:9 https://ppa.launchpadcontent.net/git-core/ppa/ubuntu noble/main amd64 Packages [2,987 B]
#7 0.758 Get:10 http://archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
#7 0.806 Get:11 http://archive.ubuntu.com/ubuntu noble/multiverse amd64 Packages [331 kB]
#7 0.849 Get:12 http://archive.ubuntu.com/ubuntu noble/main amd64 Packages [1,808 kB]
#7 0.942 Get:13 http://security.ubuntu.com/ubuntu noble-security/universe amd64 Packages [1,173 kB]
#7 0.962 Get:14 http://archive.ubuntu.com/ubuntu noble/universe amd64 Packages [19.3 MB]
#7 1.022 Get:15 http://security.ubuntu.com/ubuntu noble-security/main amd64 Packages [1,648 kB]
#7 1.661 Get:16 http://archive.ubuntu.com/ubuntu noble/restricted amd64 Packages [117 kB]
#7 1.661 Get:17 http://archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Packages [35.9 kB]
#7 1.661 Get:18 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [2,007 kB]
#7 1.688 Get:19 http://archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [2,847 kB]
#7 1.781 Get:20 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [1,941 kB]
#7 1.857 Get:21 http://archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [33.9 kB]
#7 1.858 Get:22 http://archive.ubuntu.com/ubuntu noble-backports/main amd64 Packages [49.4 kB]
#7 2.725 Get:23 https://packagecloud.io/github/git-lfs/ubuntu noble InRelease [29.2 kB]
#7 3.128 Get:24 https://packagecloud.io/github/git-lfs/ubuntu noble/main amd64 Packages [1,273 B]
#7 3.139 Fetched 34.8 MB in 3s (12.7 MB/s)
#7 3.139 Reading package lists...
#7 3.662 W: https://download.docker.com/linux/ubuntu/dists/noble/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
#7 3.663 + sudo apt-get -y install gettext-base
#7 3.697 Reading package lists...
#7 4.222 Building dependency tree...
#7 4.324 Reading state information...
#7 4.511 gettext-base is already the newest version (0.21-14ubuntu2).
#7 4.511 0 upgraded, 0 newly installed, 0 to remove and 35 not upgraded.
#7 4.513 + sudo rm -rf /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble-backports_InRelease /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble-backports_main_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble-backports_universe_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble_InRelease /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble_main_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble_multiverse_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble_restricted_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble_universe_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble-updates_InRelease /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble-updates_main_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble-updates_multiverse_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble-updates_restricted_binary-amd64_Packages.lz4 /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble-updates_universe_binary-amd64_Packages.lz4 /var/lib/apt/lists/auxfiles /var/lib/apt/lists/download.docker.com_linux_ubuntu_dists_noble_InRelease /var/lib/apt/lists/download.docker.com_linux_ubuntu_dists_noble_stable_binary-amd64_Packages.lz4 /var/lib/apt/lists/lock /var/lib/apt/lists/packagecloud.io_github_git-lfs_ubuntu_dists_noble_InRelease /var/lib/apt/lists/packagecloud.io_github_git-lfs_ubuntu_dists_noble_main_binary-amd64_Packages.lz4 /var/lib/apt/lists/partial /var/lib/apt/lists/ppa.launchpadcontent.net_git-core_ppa_ubuntu_dists_noble_InRelease /var/lib/apt/lists/ppa.launchpadcontent.net_git-core_ppa_ubuntu_dists_noble_main_binary-amd64_Packages.lz4 /var/lib/apt/lists/security.ubuntu.com_ubuntu_dists_noble-security_InRelease /var/lib/apt/lists/security.ubuntu.com_ubuntu_dists_noble-security_main_binary-amd64_Packages.lz4 /var/lib/apt/lists/security.ubuntu.com_ubuntu_dists_noble-security_multiverse_binary-amd64_Packages.lz4 /var/lib/apt/lists/security.ubuntu.com_ubuntu_dists_noble-security_restricted_binary-amd64_Packages.lz4 /var/lib/apt/lists/security.ubuntu.com_ubuntu_dists_noble-security_universe_binary-amd64_Packages.lz4
#7 DONE 4.6s

#8 [5/5] RUN dotnet tool install -g trx2junit
#8 0.335 + dotnet tool install -g trx2junit
#8 0.466 
#8 0.466 Welcome to .NET 10.0!
#8 0.466 ---------------------
#8 0.466 SDK Version: 10.0.100
#8 0.637 
#8 0.637 ----------------
#8 0.637 Installed an ASP.NET Core HTTPS development certificate.
#8 0.637 To trust the certificate, run 'dotnet dev-certs https --trust'
#8 0.637 Learn about HTTPS: https://aka.ms/dotnet-https
#8 0.637 
#8 0.637 ----------------
#8 0.637 Write your first app: https://aka.ms/dotnet-hello-world
#8 0.637 Find out what's new: https://aka.ms/dotnet-whats-new
#8 0.637 Explore documentation: https://aka.ms/dotnet-docs
#8 0.637 Report issues and find source on GitHub: https://github.com/dotnet/core
#8 0.637 Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cli
#8 0.637 --------------------------------------------------------------------------------------
#8 0.645 An issue was encountered verifying workloads. For more information, run "dotnet workload update".
#8 2.056 You can invoke the tool using the following command: trx2junit
#8 2.056 Tool 'trx2junit' (version '2.1.0') was successfully installed.
#8 DONE 2.1s

#9 exporting to image
#9 exporting layers
#9 exporting layers 1.6s done
#9 writing image sha256:224d9ce42c91f94c4e9c695cbca7ade1ff9deff2810f89cc72e0799bcf723f5c done
#9 naming to docker.io/library/dotnet-10-final-ci3 0.0s done
#9 DONE 1.7s
```
</details>