### PR TITLE
Pin .NET 10 SDK to 10.0.300

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,5 +20,15 @@
       "matchUpdateTypes": ["digest"],
       "groupName": "docker-digests"
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the .NET SDK version pinned via dotnet-install.sh --version in 10/Dockerfile",
+      "managerFilePatterns": ["/^10/Dockerfile$/"],
+      "matchStrings": ["--version (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "dotnet-sdk",
+      "datasourceTemplate": "dotnet-version"
+    }
   ]
 }

--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -16,7 +16,7 @@ RUN wget https://dot.net/v1/dotnet-install.sh && \
     gpg --verify dotnet-install.sig dotnet-install.sh && \
     # Make script executable and run installation
     chmod +x dotnet-install.sh && \
-    sudo ./dotnet-install.sh --channel 10.0 --install-dir /usr/share/dotnet && \
+    sudo ./dotnet-install.sh --version 10.0.300 --install-dir /usr/share/dotnet && \
     # Cleanup
     rm dotnet-install.sh dotnet-install.sig && \
     sudo ln -s /usr/share/dotnet/dotnet /usr/local/bin/dotnet


### PR DESCRIPTION
Switches the .NET 10 Dockerfile from `--channel 10.0` to `--version 10.0.300` so the SDK patch is reproducible.

Context: the image was shipping 10.0.203 even though local builds resolve to 10.0.300. Docker Hub caches the `RUN` layer that downloads the SDK, so `--channel 10.0` only re-resolves when the layer is invalidated. Pinning the exact version makes the patch explicit and forces a fresh download on bumps.

Reported by Eddie in https://tibber.slack.com/archives/C03BU16C3GE/p1779779873142269

Future bumps: change `--version` on line 19 when a new patch is needed. Renovate doesn't manage this line today.