### PR TITLE
Switch .NET 8 and 9 to dotnet-install.sh with pinned patches

### DIFF
--- a/8/99microsoft-dotnet.pref
+++ b/8/99microsoft-dotnet.pref
@@ -1,3 +1,0 @@
-Package: *
-Pin: origin "packages.microsoft.com"
-Pin-Priority: 1001

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -1,18 +1,33 @@
 FROM cimg/base:current@sha256:c7693014a5fe7f5c95ac54590b54e2b183995241e082eb20377761916477a3e4
 
-RUN set -x && \
-    repo_version=$(if command -v lsb_release >/dev/null 2>&1; then lsb_release -r -s; else grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"'; fi) && \
-    wget https://packages.microsoft.com/config/ubuntu/$repo_version/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
-    sudo dpkg -i packages-microsoft-prod.deb && \
-    rm packages-microsoft-prod.deb
+# Install GPG and import Microsoft's public key for dotnet-install script verification
+RUN sudo apt-get update && \
+    sudo apt-get -y install gpg && \
+    sudo rm -rf /var/lib/apt/lists/* && \
+    # Download and import Microsoft's public key
+    wget https://dot.net/v1/dotnet-install.asc && \
+    gpg --import dotnet-install.asc && \
+    rm dotnet-install.asc
 
-# Use Microsoft packages instead of Ubuntu so we can later install trx2unit
-COPY 99microsoft-dotnet.pref /etc/apt/preferences.d
+# Download, verify and install .NET SDK 8.0
+RUN wget https://dot.net/v1/dotnet-install.sh && \
+    wget https://dot.net/v1/dotnet-install.sig && \
+    # Verify the GPG signature
+    gpg --verify dotnet-install.sig dotnet-install.sh && \
+    # Make script executable and run installation
+    chmod +x dotnet-install.sh && \
+    sudo ./dotnet-install.sh --version 8.0.421 --install-dir /usr/share/dotnet && \
+    # Cleanup
+    rm dotnet-install.sh dotnet-install.sig && \
+    sudo ln -s /usr/share/dotnet/dotnet /usr/local/bin/dotnet
 
 RUN sudo apt-get update && \
-    sudo apt-get -y install gettext-base dotnet-sdk-8.0
+    sudo apt-get -y install gettext-base && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    DOTNET_ROOT=/usr/share/dotnet \
+    PATH="${PATH}:/home/circleci/.dotnet/tools"
 
 # Install trx2junit to be used during build
 RUN dotnet tool install -g trx2junit
-
-ENV PATH="${PATH}:/home/circleci/.dotnet/tools"

--- a/9/99microsoft-dotnet.pref
+++ b/9/99microsoft-dotnet.pref
@@ -1,3 +1,0 @@
-Package: *
-Pin: origin "packages.microsoft.com"
-Pin-Priority: 1001

--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -1,31 +1,33 @@
 FROM cimg/base:current@sha256:c7693014a5fe7f5c95ac54590b54e2b183995241e082eb20377761916477a3e4
 
-# This convenience image by Circle CI (https://github.com/CircleCI-Public/cimg-base) runs Ubuntu 22.04
-# in which you can install .NET 9.0 only by using backports ppa.
-# See https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#supported-distributions
+# Install GPG and import Microsoft's public key for dotnet-install script verification
+RUN sudo apt-get update && \
+    sudo apt-get -y install gpg && \
+    sudo rm -rf /var/lib/apt/lists/* && \
+    # Download and import Microsoft's public key
+    wget https://dot.net/v1/dotnet-install.asc && \
+    gpg --import dotnet-install.asc && \
+    rm dotnet-install.asc
 
-# Problem 1: Must use ppa:dotnet/backports to get .NET 9. Remove when cimg/base runs Ubuntu 24.04
-#RUN sudo add-apt-repository ppa:dotnet/backports && \
-#    sudo apt-get update && \
-#    sudo apt-get -y install gettext-base dotnet-sdk-9.0
-#RUN dotnet tool install -g trx2junit
-
-# Problem 2: ppa:dotnet/backports only provides .NET 9.0.104
-# => install .NET manually using Microsoft maintained packages
-
-RUN set -x && \
-    repo_version=$(if command -v lsb_release >/dev/null 2>&1; then lsb_release -r -s; else grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"'; fi) && \
-    wget https://packages.microsoft.com/config/ubuntu/$repo_version/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
-    sudo dpkg -i packages-microsoft-prod.deb && \
-    rm packages-microsoft-prod.deb
-
-# Use Microsoft packages instead of Ubuntu so we can later install trx2unit
-COPY 99microsoft-dotnet.pref /etc/apt/preferences.d
+# Download, verify and install .NET SDK 9.0
+RUN wget https://dot.net/v1/dotnet-install.sh && \
+    wget https://dot.net/v1/dotnet-install.sig && \
+    # Verify the GPG signature
+    gpg --verify dotnet-install.sig dotnet-install.sh && \
+    # Make script executable and run installation
+    chmod +x dotnet-install.sh && \
+    sudo ./dotnet-install.sh --version 9.0.314 --install-dir /usr/share/dotnet && \
+    # Cleanup
+    rm dotnet-install.sh dotnet-install.sig && \
+    sudo ln -s /usr/share/dotnet/dotnet /usr/local/bin/dotnet
 
 RUN sudo apt-get update && \
-    sudo apt-get -y install gettext-base dotnet-sdk-9.0
+    sudo apt-get -y install gettext-base && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    DOTNET_ROOT=/usr/share/dotnet \
+    PATH="${PATH}:/home/circleci/.dotnet/tools"
 
 # Install trx2junit to be used during build
 RUN dotnet tool install -g trx2junit
-
-ENV PATH="${PATH}:/home/circleci/.dotnet/tools"

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ List of image tags:
 
 | Tag        | Based on                                | Description                                                         |
 | :---:      | :---:                                   | :---:                                                               |
-| 8          | cimg/base:current                       | Circle CI base image with .NET `dotnet-sdk-8.0` installed from Microsofts's package repository. Supports buildx used by `aws-ecr` orb.   |
-| 9          | cimg/base:current                       | Circle CI base image with .NET `dotnet-sdk-9.0` installed from Ubuntu's package repository (backport ppa needed for 22.04). Supports buildx used by `aws-ecr` orb.   |
+| 8          | cimg/base:current                       | Circle CI base image with .NET SDK 8.0 installed via `dotnet-install.sh` w/ signature verification. Supports buildx used by `aws-ecr` orb.   |
+| 9          | cimg/base:current                       | Circle CI base image with .NET SDK 9.0 installed via `dotnet-install.sh` w/ signature verification. Supports buildx used by `aws-ecr` orb.   |
 | 10         | cimg/base:current                       | Circle CI base image with .NET SDK 10.0 installed via `dotnet-install.sh` w/ signature verification. Supports buildx used by `aws-ecr` orb.   |
 
 # This image is built in Dockerhub


### PR DESCRIPTION
## Summary
- Rewrites `8/Dockerfile` and `9/Dockerfile` to use the same `dotnet-install.sh --version X.Y.Z` flow as `10/Dockerfile` (GPG verify, install to `/usr/share/dotnet`, patch version explicit). Drops the Microsoft apt repo dance + `99microsoft-dotnet.pref` since dotnet is no longer installed via apt.
- Pins to **8.0.421** and **9.0.314** (current latest patches per [Microsoft's release-metadata feed](https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json)).

## Context
Follow-up to #34 (which pinned only 10). Same motivation: Docker Hub caches the install layer, so unpinned installs ship whatever the SDK was when the layer was first built.

Renovate config to track these new pins lives in a separate PR.

## Heads-up
.NET 8 and 9 are both in maintenance with EOL **2026-11-10** (~6 months out). The pin is still useful for reproducibility in the meantime.

## Test plan
- [ ] Docker Hub builds the 8 and 9 images successfully
- [ ] `docker run cimg-dotnet:8 dotnet --version` reports `8.0.421`
- [ ] `docker run cimg-dotnet:9 dotnet --version` reports `9.0.314`