### PR TITLE
Fix Renovate config: enable custom.regex and scope SDK pins per channel

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
-  "enabledManagers": ["dockerfile"],
+  "enabledManagers": ["dockerfile", "custom.regex"],
   "packageRules": [
     {
       "description": "Disable major docker updates",
@@ -19,15 +19,52 @@
       "matchDatasources": ["docker"],
       "matchUpdateTypes": ["digest"],
       "groupName": "docker-digests"
+    },
+    {
+      "description": "Constrain .NET 8 SDK updates to the 8.x channel",
+      "matchDatasources": ["dotnet-version"],
+      "matchDepNames": ["dotnet-sdk-8.0"],
+      "allowedVersions": "/^8\\./"
+    },
+    {
+      "description": "Constrain .NET 9 SDK updates to the 9.x channel",
+      "matchDatasources": ["dotnet-version"],
+      "matchDepNames": ["dotnet-sdk-9.0"],
+      "allowedVersions": "/^9\\./"
+    },
+    {
+      "description": "Constrain .NET 10 SDK updates to the 10.x channel",
+      "matchDatasources": ["dotnet-version"],
+      "matchDepNames": ["dotnet-sdk-10.0"],
+      "allowedVersions": "/^10\\./"
     }
   ],
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Track the .NET SDK version pinned via dotnet-install.sh --version in 10/Dockerfile",
+      "description": "Pin .NET 8 SDK via dotnet-install.sh --version in 8/Dockerfile",
+      "managerFilePatterns": ["/^8/Dockerfile$/"],
+      "matchStrings": ["--version (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "dotnet-sdk-8.0",
+      "packageNameTemplate": "dotnet-sdk",
+      "datasourceTemplate": "dotnet-version"
+    },
+    {
+      "customType": "regex",
+      "description": "Pin .NET 9 SDK via dotnet-install.sh --version in 9/Dockerfile",
+      "managerFilePatterns": ["/^9/Dockerfile$/"],
+      "matchStrings": ["--version (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "dotnet-sdk-9.0",
+      "packageNameTemplate": "dotnet-sdk",
+      "datasourceTemplate": "dotnet-version"
+    },
+    {
+      "customType": "regex",
+      "description": "Pin .NET 10 SDK via dotnet-install.sh --version in 10/Dockerfile",
       "managerFilePatterns": ["/^10/Dockerfile$/"],
       "matchStrings": ["--version (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
-      "depNameTemplate": "dotnet-sdk",
+      "depNameTemplate": "dotnet-sdk-10.0",
+      "packageNameTemplate": "dotnet-sdk",
       "datasourceTemplate": "dotnet-version"
     }
   ]


### PR DESCRIPTION
## Summary
Two fixes to `.github/renovate.json`:

1. **Adds `"custom.regex"` to `enabledManagers`.** The `customManagers` entry merged in #34 was silently skipped — when `enabledManagers` is set explicitly, only the listed managers run. The default list includes `custom.regex`, but our config only had `"dockerfile"`, so the dotnet-sdk custom manager never executed.

2. **Splits the single `dotnet-sdk` dep into three per-channel deps** (`dotnet-sdk-8.0`, `dotnet-sdk-9.0`, `dotnet-sdk-10.0`), each scoped via `packageRules.allowedVersions` to its own major channel. Without per-channel scoping, the shared `dotnet-version` lookup would mark Dockerfiles pinned to 8.0.x or 9.0.x as needing a major bump to 10.0.x — and major bumps are already disabled — so no patch PRs would ever land for the older channels.

## Context
Follow-up to #34 and a sibling of #35 (which rewrites 8/Dockerfile and 9/Dockerfile to expose `--version X.Y.Z` lines for Renovate to match).

The 8 and 9 customManager entries in this PR don't match anything until #35 merges, but they're harmless until then (no `--version X.Y.Z` in those Dockerfiles yet, so the regex finds nothing).

## Test plan
- [x] Renovate dependency dashboard lists `dotnet-sdk-10.0` (and `8.0`/`9.0` once #35 lands) as managed deps.
- [ ] No major/minor bump PRs proposed across channels.